### PR TITLE
 [Feature] Playlist - When a media end play next media

### DIFF
--- a/lib/play_list.rb
+++ b/lib/play_list.rb
@@ -24,7 +24,9 @@ class Music
       @current_media = 0 if @current_media >= @list.length
       media = @list[@current_media]
 
-      media&.play
+      return if media == nil
+
+      intern_play(media)
 
       media
     end

--- a/test/test_play_list.rb
+++ b/test/test_play_list.rb
@@ -87,6 +87,20 @@ class PlayListTest < Minitest::Test
     assert_equal [media.title, media.artist, media.album, media.genre], SECOND_MUSIC_METADATA
   end
 
+  def test_autoplay
+    play_list = load_medias
+    play_list.play
+    meta = Music.meta
+
+    assert_equal [meta[:title], meta[:artist], meta[:album], meta[:genre]], FIRST_MUSIC_METADATA
+    Music.forward(142500)
+
+    sleep(1)
+    meta = Music.meta
+
+    assert_equal [meta[:title], meta[:artist], meta[:album], meta[:genre]], SECOND_MUSIC_METADATA
+  end
+
   private
 
   def load_medias


### PR DESCRIPTION
Change method `PlayList#play` to call `PlayList#next` when the media end.

[Task](https://github.com/users/juneira/projects/1?pane=issue&itemId=25441022)